### PR TITLE
feat: dont start import if no items have been imported

### DIFF
--- a/Controller/Admin/ImportDetail.php
+++ b/Controller/Admin/ImportDetail.php
@@ -98,10 +98,11 @@ class ImportDetail extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         } else {
             return;
         }
-        $oProject->loadImportItems();
-        $oProject->updateImportProgress();
-        $oProject->assign(['ettm_project__status' => 70]);
-        $oProject->save();
+        if (0 < $oProject->loadImportItems()) {
+            $oProject->updateImportProgress();
+            $oProject->assign(['ettm_project__status' => 70]);
+            $oProject->save();
+        }
 
         $this->_aViewData['updatelist'] = 1;
         return;


### PR DESCRIPTION
After this change the "Start Import" Button in the backend will only work, if loadImportItems() returned a number higher than 0. Which means it managed to download and save items that have to be imported.

If for some reason there are no items in the eurotext project or the connection fails, the import will not start and the "Start Import" 
 button will have to be pressed again.

This commit **does not** provide an error message for the wrong behavior.